### PR TITLE
Lock progress-webpack-plugin @ 1.0.12, later breaks npm run serve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4148,7 +4148,7 @@
         "portfinder": "^1.0.26",
         "postcss": "^8.2.6",
         "postcss-loader": "^6.1.1",
-        "progress-webpack-plugin": "^1.0.12",
+        "progress-webpack-plugin": "1.0.12",
         "ssri": "^8.0.1",
         "terser-webpack-plugin": "^5.1.1",
         "thread-loader": "^3.0.0",
@@ -4729,6 +4729,23 @@
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/@vue/cli-service/node_modules/progress-webpack-plugin": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/progress-webpack-plugin/-/progress-webpack-plugin-1.0.12.tgz",
+      "integrity": "sha512-b0dMK6D7pFicDzSdh+sU0p/gp3n5QAGwjPbgacmYB/eVQpayzf9lKTQLYMnTAbk69fKoXSoVNl/+IkobJblL1A==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "figures": "^2.0.0",
+        "log-update": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@vue/cli-service/node_modules/schema-utils": {
@@ -13425,23 +13442,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/progress-webpack-plugin": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/progress-webpack-plugin/-/progress-webpack-plugin-1.0.16.tgz",
-      "integrity": "sha512-sdiHuuKOzELcBANHfrupYo+r99iPRyOnw15qX+rNlVUqXGfjXdH4IgxriKwG1kNJwVswKQHMdj1hYZMcb9jFaA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.1.0",
-        "figures": "^2.0.0",
-        "log-update": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/promise-inflight": {


### PR DESCRIPTION
Not sure hacking the dependency of a dependency in this manner is great? but it does fix `npm run serve`, and `npm run build` at least still builds